### PR TITLE
fix: pre plugin installation users not being connected

### DIFF
--- a/oidc.php
+++ b/oidc.php
@@ -128,7 +128,16 @@ function oidc_retrieve(OpenIDConnectClient $oidc, $force_registration = false) {
 		if ($config['register_new_users'] || $force_registration) {
 			// Registration is allowed, overwrite $row
 			$errors = [];
-			$row['id'] = register_user($name, random_pass(), $email, $config['notify_admins_on_register'], $errors, $config['notify_user_on_register']);
+			$existing_user_query = '
+				SELECT `id`
+				FROM users
+				WHERE `username` = \'' . $name . '\';';
+			$existing_user_row = pwg_db_fetch_assoc(pwg_query($existing_user_query));
+			if (empty($existing_user_row['id'])) {
+				$row['id'] = register_user($name, random_pass(), $email, $config['notify_admins_on_register'], $errors, $config['notify_user_on_register']);
+			} else {
+				$row['id'] = $existing_user_row['id'];
+			}
 			single_insert(OIDC_TABLE, [
 				'sub' => $sub,
 				'user_id' => $row['id'],


### PR DESCRIPTION
I installed and configured the plugin but when I tried to log back in with my account it did not work.
It turns out oidc users can't be logged in if they where already registered before the installation of the plugin.
That is a big issue for me because:
* I am the only admin
* practically all the users that are going to use oidc already exist in the database since I am migrating from a very old ldap plugin to keycloak using the same ldap server as backend.

I added a test to verify if a user with the same username already exists before registering, if so don't try to create a new user but only handle the oidc table part.